### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,6 @@
 name: CI/CD Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/agslima/nlp-emotion-api-service/security/code-scanning/2](https://github.com/agslima/nlp-emotion-api-service/security/code-scanning/2)

To address the issue, we should explicitly set a `permissions:` block for the workflow or for each job. The simplest and best fix is to add a global `permissions:` block near the top of the workflow, specifying only those scopes required. In this case, since the workflow only performs checkout, testing, linting, Docker build and push (to Docker Hub but not to GitHub Packages), the minimal required permission is likely just `contents: read`. No steps require write access to the repository or other scopes. The edit should be made in `.github/workflows/ci-cd.yml`, immediately following the `name:` declaration and prior to `on:`. No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
